### PR TITLE
Got rid of dependency on formidable

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,6 +9,5 @@
     "node": "0.6.x"
   },
   "dependencies": {
-    "formidable": "1.0.x"
   }
 }

--- a/server.js
+++ b/server.js
@@ -1,5 +1,4 @@
-var formidable = require('formidable'),
-    http = require('http'),
+var http = require('http'),
     util = require('util');
 
 http.createServer(function (req, res) {

--- a/server.js
+++ b/server.js
@@ -12,14 +12,20 @@ http.createServer(function (req, res) {
 		res.writeHead(200, {'Content-Type': 'text/plain'});
 		res.end("Hello!\n");    
 	} else if (req.url == '/upload' && req.method.toLowerCase() == 'post') {
-        var form = new formidable.IncomingForm();
-        form.parse(req, function(err, fields, files) {
+        var body = '';
+
+        req.on('data', function (data) {
+            body += data;
+
+            if (body.length > 1e6) {
+                req.conection.distroy();
+            }
+        });
+
+        req.on('end', function () {
             res.writeHead(200, {'content-type': 'text/plain'});
-            console.log(util.inspect({fields: fields, files: files}));
-            
             res.write('received upload:\n\n');
-            res.write(util.inspect({fields: fields, files: files}));
-            console.log
+            res.write(body);
             res.end("\n");
         });
 	} else if (req.url.match(/\d{3}/)) { 


### PR DESCRIPTION
I was running into issues with testing my XHR2 stuff using your server.  Was failing in the formidable module so I just refactored it out.

This should still do everything that was required for this server but make it easier to use for my XHR2 tests and reduce the dependency.
